### PR TITLE
URL Cleanup

### DIFF
--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -5,7 +5,7 @@ Information on Apache FOP dependencies
 $Id$
 
 The Apache Licenses can also be found here:
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 Normal Dependencies

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
@@ -1,6 +1,6 @@
                                   Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/src/appendix-schema.xml
+++ b/doc/reference/src/appendix-schema.xml
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/example/Spring.Data.Gemfire.HelloWorld/CommandProcessor.cs
+++ b/example/Spring.Data.Gemfire.HelloWorld/CommandProcessor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/example/Spring.Data.Gemfire.HelloWorld/HelloWorld.cs
+++ b/example/Spring.Data.Gemfire.HelloWorld/HelloWorld.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/AllKeysInterest.cs
+++ b/src/Spring.Data.GemFire/AllKeysInterest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,7 +49,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public AllKeysInterest(bool durable)
@@ -74,7 +74,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public AllKeysInterest(InterestResultPolicy policy, bool durable)
@@ -104,7 +104,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public bool Durable

--- a/src/Spring.Data.GemFire/CacheFactoryObject.cs
+++ b/src/Spring.Data.GemFire/CacheFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Caching/GemFireCache.cs
+++ b/src/Spring.Data.GemFire/Caching/GemFireCache.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Caching/NamespaceDoc.cs
+++ b/src/Spring.Data.GemFire/Caching/NamespaceDoc.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/ClientRegionFactoryObject.cs
+++ b/src/Spring.Data.GemFire/ClientRegionFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/CacheParser.cs
+++ b/src/Spring.Data.GemFire/Config/CacheParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/ClientRegionParser.cs
+++ b/src/Spring.Data.GemFire/Config/ClientRegionParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/GemfireNamespaceParser.cs
+++ b/src/Spring.Data.GemFire/Config/GemfireNamespaceParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/LookupRegionParser.cs
+++ b/src/Spring.Data.GemFire/Config/LookupRegionParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/NamespaceDoc.cs
+++ b/src/Spring.Data.GemFire/Config/NamespaceDoc.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/ParsingUtils.cs
+++ b/src/Spring.Data.GemFire/Config/ParsingUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/Config/PoolParser.cs
+++ b/src/Spring.Data.GemFire/Config/PoolParser.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/GemFireCacheUtils.cs
+++ b/src/Spring.Data.GemFire/GemFireCacheUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/GemFireSystemException.cs
+++ b/src/Spring.Data.GemFire/GemFireSystemException.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/IInterest.cs
+++ b/src/Spring.Data.GemFire/IInterest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         bool Durable { get; set; }

--- a/src/Spring.Data.GemFire/InterestResultPolicy.cs
+++ b/src/Spring.Data.GemFire/InterestResultPolicy.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/KeyInterest.cs
+++ b/src/Spring.Data.GemFire/KeyInterest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -63,7 +63,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public KeyInterest(ICacheableKey[] keys, bool durable)
@@ -90,7 +90,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public KeyInterest(ICacheableKey[] keys, InterestResultPolicy policy, bool durable)

--- a/src/Spring.Data.GemFire/NamespaceDoc.cs
+++ b/src/Spring.Data.GemFire/NamespaceDoc.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/PoolConnection.cs
+++ b/src/Spring.Data.GemFire/PoolConnection.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/PoolFactoryDefaults.cs
+++ b/src/Spring.Data.GemFire/PoolFactoryDefaults.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/PoolFactoryObject.cs
+++ b/src/Spring.Data.GemFire/PoolFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/RegexInterest.cs
+++ b/src/Spring.Data.GemFire/RegexInterest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -60,7 +60,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public RegexInterest(string regex, bool durable)
@@ -87,7 +87,7 @@ namespace Spring.Data.GemFire
         /// <remarks>
         /// The client can register any of its interest lists and continuous queries as durable. 
         /// Durable interest remains even if the client disconnects for a period of time. 
-        /// During the client’s down time, the server maintains its durable subscriptions and then, 
+        /// During the clientï¿½s down time, the server maintains its durable subscriptions and then, 
         /// when the client reconnects, plays them back to the client.
         /// </remarks>
         public RegexInterest(string regex, InterestResultPolicy policy, bool durable)

--- a/src/Spring.Data.GemFire/RegionAttributesFactoryObject.cs
+++ b/src/Spring.Data.GemFire/RegionAttributesFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Data.GemFire/RegionLookupFactoryObject.cs
+++ b/src/Spring.Data.GemFire/RegionLookupFactoryObject.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/CacheIntegrationTests.cs
+++ b/test/Spring.Data.GemFire.Tests/CacheIntegrationTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/Caching/AbstractGemfireCacheTests.cs
+++ b/test/Spring.Data.GemFire.Tests/Caching/AbstractGemfireCacheTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/Caching/XmlBasedGemfireCacheTests.cs
+++ b/test/Spring.Data.GemFire.Tests/Caching/XmlBasedGemfireCacheTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/CommonTypes.cs
+++ b/test/Spring.Data.GemFire.Tests/CommonTypes.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/Config/CacheNamespaceTests.cs
+++ b/test/Spring.Data.GemFire.Tests/Config/CacheNamespaceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/Config/ClientRegionNamespaceTests.cs
+++ b/test/Spring.Data.GemFire.Tests/Config/ClientRegionNamespaceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/Config/PoolNamespaceTests.cs
+++ b/test/Spring.Data.GemFire.Tests/Config/PoolNamespaceTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/RegionIntegrationTests.cs
+++ b/test/Spring.Data.GemFire.Tests/RegionIntegrationTests.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/SimpleCacheListener.cs
+++ b/test/Spring.Data.GemFire.Tests/SimpleCacheListener.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/SimpleCacheLoader.cs
+++ b/test/Spring.Data.GemFire.Tests/SimpleCacheLoader.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/SimpleCacheWriter.cs
+++ b/test/Spring.Data.GemFire.Tests/SimpleCacheWriter.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Data.GemFire.Tests/TestUtils.cs
+++ b/test/Spring.Data.GemFire.Tests/TestUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 12 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 49 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).